### PR TITLE
FIX: Events Sync (Yafim Kolyshkin)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+/.idea

--- a/emitter-sync-pattern.ts
+++ b/emitter-sync-pattern.ts
@@ -62,28 +62,25 @@ class EventHandler extends EventStatistics<EventName> {
   // Feel free to edit this class
 
   repository: EventRepository;
+  subscriptions: EventName[];
 
   constructor(emitter: EventEmitter<EventName>, repository: EventRepository) {
     super();
     this.repository = repository;
+    this.subscriptions = [EventName.EventA, EventName.EventB];
 
-    emitter.subscribe(EventName.EventA, () =>
-      this.repository.saveEventData(EventName.EventA, 1)
-    );
+    this.subscriptions.map(event => {
+      emitter.subscribe(event, () => {
+        this.setStats(event, this.getStats(event) + 1);
+        this.repository.setStats(event, this.repository.getStats(event) + 1);
+      })
+    })
   }
 }
 
+
 class EventRepository extends EventDelayedRepository<EventName> {
   // Feel free to edit this class
-
-  async saveEventData(eventName: EventName, _: number) {
-    try {
-      await this.updateEventStatsBy(eventName, 1);
-    } catch (e) {
-      // const _error = e as EventRepositoryError;
-      // console.warn(error);
-    }
-  }
 }
 
 init();


### PR DESCRIPTION
Since the parent class `EventStatistics` implements synchronous `.getStats()` and `.setStats()` methods, which are used to get and set values respectively. Based on this, the child classes `EventHandler` and `EventRepository` can directly access these methods to set the `.eventStats()` value. This allows us to avoid all the possible problems hidden inside the `await .updateEventStatsBy()` method of the `EventDelayedRepository` class.

**Q:** Is it necessary to use `await .updateEventStatsBy()` method for this task? In case, feel free to reach me out :) 
